### PR TITLE
MindMap: フェーズ1（リスト表示＋編集）追加

### DIFF
--- a/app/src/main/java/com/example/bugmemo/ui/screens/MindMapScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/MindMapScreen.kt
@@ -3,8 +3,7 @@
 
 package com.example.bugmemo.ui.screens
 
-// ★ Changed: フェーズ0の実 UI（InMemory CRUD）に差し替え
-// ★ Changed: 既存アプリ機能に影響しない“単独画面”として動作
+// ★ keep: フェーズ0→1へ。既存機能に影響しない“単独画面”として動作
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -45,10 +44,10 @@ fun MindMapScreen(
     onClose: () -> Unit = {},
     vm: MindMapViewModel = viewModel(),
 ) {
-    // ★ Added: ViewModel が公開する nodes を購読（未使用警告の解消＆再描画トリガ）
+    // ★ Added: ViewModel が公開する nodes(StateFlow) を購読（未使用警告の解消＆再描画トリガ）
     val nodes by vm.nodes.collectAsStateWithLifecycle(initialValue = emptyList())
 
-    // ★ Changed: flatList() の再計算を nodes の変化に結びつける（remember(nodes)）
+    // ★ Changed: flatList() の再計算を nodes の変化に結びつける（remember(nodes) でメモ化）
     val flat = remember(nodes) { vm.flatList() }
 
     var newTitle by remember { mutableStateOf("") }
@@ -57,7 +56,7 @@ fun MindMapScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    // ★ Added: 件数を軽く表示して購読を明示
+                    // ★ Added: 件数を簡易表示して購読を明示
                     Text("Mind Map（${nodes.size}）")
                 },
                 navigationIcon = {
@@ -75,7 +74,7 @@ fun MindMapScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            // ★ Added: ルートノードの追加（最小）
+            // ★ keep: ルートノードの追加（最小 UI）
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
                     value = newTitle,
@@ -93,7 +92,7 @@ fun MindMapScreen(
                 ) { Text("追加") }
             }
 
-            // ★ keep: 簡易ツリー（インデント表示）
+            // ★ keep: 簡易ツリー（インデント表示；(node, depth) を表示）
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
### 概要
Mind Map の最小機能（ノードの一覧表示／追加／改名／削除）を デバッグビルド限定 で試験導入。
既存のノート機能やCIを壊さない段階導入。

### 変更点
## FeatureFlags.kt
- ENABLE_MIND_MAP_DEBUG を追加（BuildConfig.DEBUG をラップ）。
## BugsScreen.kt
- AppBar のアクションに デバッグ時のみ Mind Map 画面への導線を追加。
## Nav.kt
- Routes.MINDMAP を追加。UIからは非表示ルートとして受け口だけ用意。
- MindMapScreen を登録。MindMapViewModel は画面ローカルで生成。
## MindMapScreen.kt
- フェーズ1UI：ノードの一覧・追加・名称変更・削除。インデントで親子を簡易表示。
- collectAsStateWithLifecycle で nodes を購読、remember(nodes) で flatList() を再計算。

### 動作確認
## Mind Map 画面で以下を確認
- テキスト入力→「追加」でノードが増える
- 既存ノードの「編集」→保存でタイトルが更新される
- ゴミ箱アイコンで削除できる
- 追加/編集/削除後にリストが即時反映される

### チェックリスト
- [x] ./gradlew spotlessCheck test :app:lint assembleDebug 通過
- [x] Debug で動作確認、Release で非表示を確認
- [x] 影響範囲が既存機能に波及していない
