### PR TITLE
NoteEditorScreen:文言を stringResource 化（タイトル/本文ラベル・AppBar CD）

### DIFF
--- a/app/src/main/java/com/example/bugmemo/ui/screens/NoteEditorScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/NoteEditorScreen.kt
@@ -25,8 +25,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource // ★ Added: stringResource を使うため追加
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.bugmemo.R // ★ Added: R参照（strings.xml のキー参照に必要）
 import com.example.bugmemo.ui.NotesViewModel
 
 // ★ Removed: LaunchedEffect の import（自動 newNote 初期化は廃止）
@@ -36,7 +38,7 @@ import com.example.bugmemo.ui.NotesViewModel
 
 @Composable
 fun NoteEditorScreen(
-    // ★ Changed: デフォルトの viewModel() を削除。呼び出し側（Nav/AppScaffold）から同一 VM を受け取る。
+    // ★ keep: デフォルトの viewModel() は削除済み。呼び出し側（Nav/AppScaffold）から同一 VM を受け取る。
     vm: NotesViewModel,
     onBack: () -> Unit = {},
 ) {
@@ -51,8 +53,13 @@ fun NoteEditorScreen(
         topBar = {
             TopAppBar(
                 title = {
+                    // ★ Changed: ハードコードを stringResource に置換
+                    //   - 空タイトル時: label_untitled（例: "(無題)"）
+                    //   - 新規時(null): title_new_note（例: "新規メモ"）
+                    val titleText = editing?.title?.ifBlank { stringResource(R.string.label_untitled) }
+                        ?: stringResource(R.string.title_new_note) // ★ Changed
                     Text(
-                        text = editing?.title?.ifBlank { "(無題)" } ?: "新規メモ",
+                        text = titleText, // ★ Changed
                         style = MaterialTheme.typography.titleLarge,
                     )
                 },
@@ -60,7 +67,8 @@ fun NoteEditorScreen(
                     IconButton(onClick = onBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
+                            contentDescription = stringResource(R.string.cd_back),
+                            // ★ Changed: "Back" → リソース
                         )
                     }
                 },
@@ -72,7 +80,8 @@ fun NoteEditorScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Save,
-                            contentDescription = "Save",
+                            contentDescription = stringResource(R.string.cd_save),
+                            // ★ Changed: "Save" → リソース
                         )
                     }
                 },
@@ -85,14 +94,15 @@ fun NoteEditorScreen(
                 .fillMaxSize()
                 .padding(16.dp)
                 .verticalScroll(rememberScrollState()),
-            // ★ Added: 画面全体（エディタ領域）を縦スクロール可能に
+            // ★ keep: 画面全体（エディタ領域）を縦スクロール可能に
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             // タイトル
             OutlinedTextField(
                 value = editing?.title.orEmpty(),
                 onValueChange = { text -> vm.setEditingTitle(text) },
-                label = { Text("タイトル") },
+                label = { Text(stringResource(R.string.label_title)) },
+                // ★ Changed: "タイトル" → リソース
                 singleLine = true,
                 // ★ keep: 準備完了まで入力不可
                 enabled = enabled,
@@ -103,7 +113,8 @@ fun NoteEditorScreen(
             OutlinedTextField(
                 value = editing?.content.orEmpty(),
                 onValueChange = { text -> vm.setEditingContent(text) },
-                label = { Text("内容") },
+                label = { Text(stringResource(R.string.label_content)) },
+                // ★ Changed: "内容" → リソース
                 // ★ keep: 準備完了まで入力不可
                 enabled = enabled,
                 modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,37 +4,55 @@
     <string name="app_name">Bug Memo</string>
 
     <!-- 画面タイトル -->
-    <string name="title_bugmemo_with_label">Bug Memo — %1$s</string> <!-- ★ Added -->
-    <string name="title_mindmap_with_count">Mind Map（%1$d）</string> <!-- ★ Added -->
+    <string name="title_bugmemo_with_label">Bug Memo — %1$s</string> <!-- ★ keep: 共有済み -->
+    <string name="title_mindmap_with_count">Mind Map（%1$d）</string> <!-- ★ keep: 共有済み -->
+    <string name="title_bugmemo">Bug Memo</string> <!-- ★ Added: 無フィルタ時のタイトル用（BugsScreenのAppBar） -->
 
     <!-- アクション / ボタン -->
-    <string name="action_add">追加</string> <!-- ★ Added -->
-    <string name="action_edit">編集</string> <!-- ★ Added -->
-    <string name="action_child_add_open">子ノードを追加</string> <!-- ★ Added -->
-    <string name="action_child_add_close">閉じる</string> <!-- ★ Added -->
-    <string name="action_folders">フォルダ</string> <!-- ★ Added -->
-    <string name="action_search">検索</string> <!-- ★ Added -->
-    <string name="action_mindmap_dev">Mind Map（試験機能）</string> <!-- ★ Added -->
+    <string name="action_add">追加</string> <!-- ★ keep -->
+    <string name="action_edit">編集</string> <!-- ★ keep -->
+    <string name="action_child_add_open">子ノードを追加</string> <!-- ★ keep -->
+    <string name="action_child_add_close">閉じる</string> <!-- ★ keep -->
+    <string name="action_folders">フォルダ</string> <!-- ★ keep -->
+    <string name="action_search">検索</string> <!-- ★ keep -->
+    <string name="action_mindmap_dev">Mind Map（試験機能）</string> <!-- ★ keep -->
 
     <!-- 入力ラベル -->
-    <string name="label_new_root_node">新規ノード（ルート）</string> <!-- ★ Added -->
-    <string name="label_name">名称</string> <!-- ★ Added -->
-    <string name="label_child_name">子ノード名</string> <!-- ★ Added -->
-    <string name="label_no_folder">フォルダ未選択</string> <!-- 既存画面と表現合わせに利用可 -->
+    <string name="label_new_root_node">新規ノード（ルート）</string> <!-- ★ keep -->
+    <string name="label_name">名称</string> <!-- ★ keep -->
+    <string name="label_child_name">子ノード名</string> <!-- ★ keep -->
+    <string name="label_no_folder">フォルダ未選択</string> <!-- ★ keep -->
 
     <!-- Snackbar / トースト -->
-    <string name="snack_root_added">ルートに追加しました</string> <!-- ★ Added -->
-    <string name="snack_renamed">名称を更新しました</string> <!-- ★ Added -->
-    <string name="snack_deleted">削除しました</string> <!-- ★ Added -->
-    <string name="snack_child_added">子ノードを追加しました</string> <!-- ★ Added -->
-    <string name="snack_undo">取り消す</string> <!-- ★ Added -->
+    <string name="snack_root_added">ルートに追加しました</string> <!-- ★ keep -->
+    <string name="snack_renamed">名称を更新しました</string> <!-- ★ keep -->
+    <string name="snack_deleted">削除しました</string> <!-- ★ keep -->
+    <string name="snack_child_added">子ノードを追加しました</string> <!-- ★ keep -->
+    <string name="snack_undo">取り消す</string> <!-- ★ keep -->
 
     <!-- contentDescription（アクセシビリティ） -->
-    <string name="cd_back">戻る</string> <!-- ★ Added -->
-    <string name="cd_save">保存</string> <!-- ★ Added -->
-    <string name="cd_delete">削除</string> <!-- ★ Added -->
-    <string name="cd_new_note">新規作成</string> <!-- ★ Added -->
-    <string name="cd_open_folders">フォルダ</string> <!-- ★ Added -->
-    <string name="cd_open_search">検索</string> <!-- ★ Added -->
-    <string name="cd_open_mindmap_dev">Mind Map（試験機能）</string> <!-- ★ Added -->
+    <string name="cd_back">戻る</string> <!-- ★ keep -->
+    <string name="cd_save">保存</string> <!-- ★ keep -->
+    <string name="cd_delete">削除</string> <!-- ★ keep -->
+    <string name="cd_new_note">新規作成</string> <!-- ★ keep -->
+    <string name="cd_open_folders">フォルダ</string> <!-- ★ keep -->
+    <string name="cd_open_search">検索</string> <!-- ★ keep -->
+    <string name="cd_open_mindmap_dev">Mind Map（試験機能）</string> <!-- ★ keep -->
+    <string name="cd_clear_folder_filter">フォルダ絞り込みを解除</string> <!-- ★ Added: BugsScreenのClearボタン用 -->
+
+    <!-- 空状態（将来の置き換え用: 現状未使用なら保持だけ） -->
+    <string name="empty_no_memo">メモがありません</string> <!-- ★ Added: EmptyMessage 文言 -->
+    <string name="empty_tip_create">右下の + から作成しましょう</string> <!-- ★ Added: EmptyMessage 補助 -->
+
+    <!-- メニュー（将来の置き換え用: 現状未使用なら保持だけ） -->
+    <string name="menu_unselected_none">未選択（なし）</string> <!-- ★ Added: フォルダ選択メニューの見直し用 -->
+
+    <!-- 追加分(穴埋め追加用) -->
+    <string name="label_untitled">無題</string>
+    <string name="title_new_note">新規メモ</string>
+    <string name="label_title">タイトル</string>
+    <string name="label_content">内容</string>
+
+
+
 </resources>


### PR DESCRIPTION
## 目的
NoteEditorScreen における文言のリソース化

## 追加する文字列リソース
- **title_new_note(新規メモ)**
- **label_untitled(無題)**
- **label_title(タイトル)**
- **label_content(内容)**

## 変更点
- CD（contentDescription）は必ず cd_ で統一（アクセシビリティレビューがしやすい）