### PR TITLE
Note/MindMap:エディタでキーボード重なりを回避（imePadding() 追加）

### DIFF
--- a/app/src/main/java/com/example/bugmemo/ui/screens/MindMapScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/MindMapScreen.kt
@@ -4,13 +4,15 @@
 package com.example.bugmemo.ui.screens
 
 // ★ keep: フェーズ0→1へ。既存機能に影響しない“単独画面”として動作
-
 // ★ keep: フォーカス/IME対応・Snackbar用のimport
+// ★ Added: キーボード表示時の下部被り回避に使用(androidx.compose.foundation.layout.imePadding)
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -50,7 +52,7 @@ import com.example.bugmemo.ui.mindmap.MindNode
 import kotlinx.coroutines.launch
 
 // ★ keep: StateFlow を Compose で購読するための拡張関数を使用（collectAsStateWithLifecycle）
-// ★ Added: Undo アクション結果の判定に使用(androidx.compose.material3.SnackbarResult)
+// ★ keep: Undo アクション結果の判定に使用(androidx.compose.material3.SnackbarResult)
 
 @Composable
 fun MindMapScreen(
@@ -89,7 +91,9 @@ fun MindMapScreen(
             Modifier
                 .padding(inner)
                 .fillMaxSize()
-                .padding(16.dp),
+                .padding(16.dp)
+                .imePadding(),
+            // ★ Added: IME(ソフトキーボード)表示時に下部が隠れないよう余白を付与
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             // ★ keep: ルートノードの追加（最小 UI）
@@ -137,18 +141,16 @@ fun MindMapScreen(
                             scope.launch { snackbarHostState.showSnackbar("名称を更新しました") }
                         },
                         onDelete = {
-                            // ★ Changed: 削除 → Snackbar で「取り消す」アクションを提示し、押下で vm.undoDelete() を呼ぶ
+                            // ★ keep: 削除 → Snackbar で「取り消す」アクションを提示し、押下で vm.undoDelete() を呼ぶ
                             vm.deleteNode(node.id)
                             scope.launch {
                                 val result = snackbarHostState.showSnackbar(
                                     message = "削除しました",
-                                    actionLabel = if (vm.canUndoDelete()) "取り消す" else null, // ★ Added
+                                    actionLabel = if (vm.canUndoDelete()) "取り消す" else null,
                                     withDismissAction = true,
-                                    // ★ Added: 明示的に閉じる操作も可
                                 )
                                 if (result == SnackbarResult.ActionPerformed) {
                                     vm.undoDelete()
-                                    // ★ Added: 取り消し実行
                                 }
                             }
                         },

--- a/app/src/main/java/com/example/bugmemo/ui/screens/NoteEditorScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/NoteEditorScreen.kt
@@ -3,12 +3,14 @@
 
 package com.example.bugmemo.ui.screens
 
-// ★ Added: スクロール対応のため foundation の API を使用（import ブロックにはコメントを挟まない）
+// ★ Added: IME回避 で imePadding を使うための import を追加
+// ★ keep: import ブロック内に行末コメントは入れない（ktlint 配慮）
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -25,26 +27,24 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource // ★ Added: stringResource を使うため追加
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.example.bugmemo.R // ★ Added: R参照（strings.xml のキー参照に必要）
+import com.example.bugmemo.R
 import com.example.bugmemo.ui.NotesViewModel
 
+// ★ Added: stringResource を使うため追加(androidx.compose.ui.res.stringResource)
+// ★ Added: R参照（strings.xml のキー参照に必要）
 // ★ Removed: LaunchedEffect の import（自動 newNote 初期化は廃止）
-// import androidx.compose.runtime.LaunchedEffect
 // ★ Removed: 画面内での viewModel() 生成は廃止（呼び出し側から受け取るため）
-// import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
 fun NoteEditorScreen(
-    // ★ keep: デフォルトの viewModel() は削除済み。呼び出し側（Nav/AppScaffold）から同一 VM を受け取る。
+    // ★ keep: 呼び出し側から同一 VM を受け取る（画面内での viewModel() 生成はしない）
     vm: NotesViewModel,
     onBack: () -> Unit = {},
 ) {
     val editing by vm.editing.collectAsStateWithLifecycle(initialValue = null)
-
-    // ★ Removed: 入場時の自動 newNote() 初期化（検索→編集直後の上書き事故を防止）
 
     // ★ keep: 編集対象が準備できるまで入力や保存を無効化
     val enabled = editing != null
@@ -53,13 +53,11 @@ fun NoteEditorScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    // ★ Changed: ハードコードを stringResource に置換
-                    //   - 空タイトル時: label_untitled（例: "(無題)"）
-                    //   - 新規時(null): title_new_note（例: "新規メモ"）
+                    // ★ Changed: タイトルのリソース化（空なら label_untitled / 新規なら title_new_note）
                     val titleText = editing?.title?.ifBlank { stringResource(R.string.label_untitled) }
-                        ?: stringResource(R.string.title_new_note) // ★ Changed
+                        ?: stringResource(R.string.title_new_note)
                     Text(
-                        text = titleText, // ★ Changed
+                        text = titleText,
                         style = MaterialTheme.typography.titleLarge,
                     )
                 },
@@ -67,21 +65,20 @@ fun NoteEditorScreen(
                     IconButton(onClick = onBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            // ★ Changed: CD をリソース化
                             contentDescription = stringResource(R.string.cd_back),
-                            // ★ Changed: "Back" → リソース
                         )
                     }
                 },
                 actions = {
                     IconButton(
                         onClick = { vm.saveEditing() },
-                        // ★ keep: 編集対象が無いときは保存を無効化
                         enabled = enabled,
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Save,
+                            // ★ Changed: CD をリソース化
                             contentDescription = stringResource(R.string.cd_save),
-                            // ★ Changed: "Save" → リソース
                         )
                     }
                 },
@@ -93,18 +90,18 @@ fun NoteEditorScreen(
                 .padding(inner)
                 .fillMaxSize()
                 .padding(16.dp)
-                .verticalScroll(rememberScrollState()),
-            // ★ keep: 画面全体（エディタ領域）を縦スクロール可能に
+                .verticalScroll(rememberScrollState())
+                .imePadding(),
+            // ★ Added: ソフトキーボード表示時の下部被りを自動回避
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             // タイトル
             OutlinedTextField(
                 value = editing?.title.orEmpty(),
                 onValueChange = { text -> vm.setEditingTitle(text) },
+                // ★ Changed: ラベルのリソース化
                 label = { Text(stringResource(R.string.label_title)) },
-                // ★ Changed: "タイトル" → リソース
                 singleLine = true,
-                // ★ keep: 準備完了まで入力不可
                 enabled = enabled,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -113,16 +110,15 @@ fun NoteEditorScreen(
             OutlinedTextField(
                 value = editing?.content.orEmpty(),
                 onValueChange = { text -> vm.setEditingContent(text) },
+                // ★ Changed: ラベルのリソース化
                 label = { Text(stringResource(R.string.label_content)) },
-                // ★ Changed: "内容" → リソース
-                // ★ keep: 準備完了まで入力不可
                 enabled = enabled,
                 modifier = Modifier
                     .fillMaxWidth()
-                    // ★ keep: エディタ内である程度の高さを確保
                     .weight(1f)
-                    // 読みやすさのための最小高さ
+                    // ★ keep: エディタ領域をできるだけ広く
                     .heightIn(min = 160.dp),
+                // ★ keep: 読みやすさのための最小高さ
                 minLines = 8,
             )
         }


### PR DESCRIPTION
### 目的
Note/MindMap エディタでキーボード重なりを回避（imePadding() 追加）

### 変更概要
- ソフトキーボード表示時に、エディタ下部の入力欄やボタンが隠れることがあったため、Compose の imePadding() を適用して 下部被りを回避。
- 見た目・操作性（UX）を改善する小粒変更。機能仕様の追加・変更は無し。

### 変更点
## 追加（import）
-import androidx.compose.foundation.layout.imePadding
## 適用（Modifier）
- ルート Column に .imePadding() を付与し、IME 出現時のインセット分だけ下余白を自動調整

### 変更ファイル
## NoteEditorScreen.kt
- ルート Column の Modifier に .imePadding() を追加
- 上記に伴い imePadding の import を追加

## MindMapScreen.kt
- ルート Column の Modifier に .imePadding() を追加（入力行が隠れないように）
- 上記に伴い imePadding の import を追加