### PR TITLE
Settings: 設定画面の骨組み＋言語切替（即時反映）/ 文言リソース化 / imePadding / baseline整備

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,9 @@ dependencies {
     // DataStore（フォルダ絞り込み・検索語の保存/復元で使用）
     implementation(libs.androidx.datastore.preferences)
 
+    // Appcompat
+    implementation(libs.androidx.appcompat)
+
     // Room
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -2,17 +2,6 @@
 <issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
 
     <issue
-        id="RedundantLabel"
-        message="Redundant label can be removed"
-        errorLine1="            android:label=&quot;@string/app_name&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/AndroidManifest.xml"
-            line="17"
-            column="13"/>
-    </issue>
-
-    <issue
         id="AndroidGradlePluginVersion"
         message="A newer version of Gradle than 8.13 is available: 8.14.3"
         errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip"
@@ -22,51 +11,7 @@
             line="4"
             column="17"/>
     </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room:room-compiler than 2.8.1 is available: 2.8.2"
-        errorLine1="room = &quot;2.8.1&quot;               # KSP とは別（Room 本体のバージョン）"
-        errorLine2="       ~~~~~~~">
-        <location
-            file="$HOME/AndroidStudioProjects/bugmemo/gradle/libs.versions.toml"
-            line="12"
-            column="8"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room:room-ktx than 2.8.1 is available: 2.8.2"
-        errorLine1="room = &quot;2.8.1&quot;               # KSP とは別（Room 本体のバージョン）"
-        errorLine2="       ~~~~~~~">
-        <location
-            file="$HOME/AndroidStudioProjects/bugmemo/gradle/libs.versions.toml"
-            line="12"
-            column="8"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room:room-runtime than 2.8.1 is available: 2.8.2"
-        errorLine1="room = &quot;2.8.1&quot;               # KSP とは別（Room 本体のバージョン）"
-        errorLine2="       ~~~~~~~">
-        <location
-            file="$HOME/AndroidStudioProjects/bugmemo/gradle/libs.versions.toml"
-            line="12"
-            column="8"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.compose:compose-bom than 2025.09.01 is available: 2025.10.00"
-        errorLine1="composeBom = &quot;2025.09.01&quot;"
-        errorLine2="             ~~~~~~~~~~~~">
-        <location
-            file="$HOME/AndroidStudioProjects/bugmemo/gradle/libs.versions.toml"
-            line="15"
-            column="14"/>
-    </issue>
-
+    
     <issue
         id="ObsoleteSdkInt"
         message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 34. Merge all the resources in this folder into `mipmap-anydpi`.">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    >
+    <!-- ★ Removed: 未使用の tools 名前空間 -->
 
     <application
         android:allowBackup="true"
@@ -14,14 +15,12 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Bugmemo">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
-
+    <!-- ★ Removed: アプリ側と同一の label は冗長なので削除 -->
 </manifest>

--- a/app/src/main/java/com/example/bugmemo/core/AppLocaleManager.kt
+++ b/app/src/main/java/com/example/bugmemo/core/AppLocaleManager.kt
@@ -1,0 +1,41 @@
+package com.example.bugmemo.core
+
+// ★ Added: アプリ内から言語を切り替える最小ユーティリティ（DataStore + AppCompatDelegate）
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+
+private const val PREFS_NAME = "app_settings"
+private val Context.dataStore by preferencesDataStore(name = PREFS_NAME)
+
+// ★ keep: 空文字は「システムに追従」、それ以外は BCP47 の言語タグ（例: "ja", "en"）
+object AppLocaleManager {
+    private val KEY_LANGUAGE_TAG = stringPreferencesKey("language_tag")
+
+    fun languageTagFlow(context: Context): Flow<String> = context.dataStore.data
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .map { prefs -> prefs[KEY_LANGUAGE_TAG] ?: "" }
+
+    suspend fun setLanguage(context: Context, languageTag: String) {
+        // ★ Changed: DataStore に保存
+        context.dataStore.edit { it[KEY_LANGUAGE_TAG] = languageTag }
+
+        // ★ Changed: 反映（即時）。空文字はシステムに追従。
+        val locales = if (languageTag.isBlank()) {
+            LocaleListCompat.getEmptyLocaleList()
+        } else {
+            LocaleListCompat.forLanguageTags(languageTag)
+        }
+        AppCompatDelegate.setApplicationLocales(locales)
+        // ※ Activity 再生成は呼び出し側で必要に応じて行ってください
+    }
+}

--- a/app/src/main/java/com/example/bugmemo/ui/screens/BugsScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/BugsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings // ★ Added: 設定アイコン
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.Button
@@ -65,10 +66,6 @@ import com.example.bugmemo.ui.NotesViewModel
 // ★ Added: R を参照(com.example.bugmemo.R)
 // ★ Added: スクロール用の状態を追加(androidx.compose.foundation.rememberScrollState)
 // ★ Added: 縦スクロール修飾子を追加(androidx.compose.foundation.verticalScroll)
-// ★ Removed: BuildConfig 直接参照は不要
-// import com.example.bugmemo.BuildConfig
-// ★ Removed: デフォルト生成をやめたため不要
-// import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
 fun BugsScreen(
@@ -78,6 +75,7 @@ fun BugsScreen(
     onOpenSearch: () -> Unit = {},
     onOpenFolders: () -> Unit = {},
     onOpenMindMap: () -> Unit = {},
+    onOpenSettings: () -> Unit = {}, // ★ Added: 設定画面への遷移フック（NavGraph から受け取る）
     // ★ keep: MindMap への導線（Nav から渡す）
 ) {
     val notes by vm.notes.collectAsStateWithLifecycle(initialValue = emptyList())
@@ -102,6 +100,15 @@ fun BugsScreen(
                     )
                 },
                 actions = {
+                    // ★ Added: 設定（常時表示・最左）※CD は strings 追加後に差し替え推奨
+                    IconButton(onClick = onOpenSettings) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = stringResource(R.string.cd_open_settings),
+                            // ★ 差し替え
+                        )
+                    }
+                    // ★ keep: 以下既存
                     if (filterFolderId != null) {
                         IconButton(onClick = { vm.setFolderFilter(null) }) {
                             // ★ Changed: CD をリソース化（クリア→delete の文言を流用）

--- a/app/src/main/java/com/example/bugmemo/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/SettingsScreen.kt
@@ -1,0 +1,119 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.bugmemo.ui.screens
+
+// ★ Added: 設定画面（言語切替のみ・最小）
+
+import android.app.Activity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.bugmemo.R
+import com.example.bugmemo.core.AppLocaleManager
+import kotlinx.coroutines.launch
+
+@Composable
+fun SettingsScreen(
+    onBack: () -> Unit = {},
+) {
+    val ctx = LocalContext.current
+    val activity = ctx as? Activity
+
+    // ★ Added: 現在の言語タグを購読（""=システム追従 / "ja" / "en"）
+    val languageTag by AppLocaleManager.languageTagFlow(ctx)
+        .collectAsStateWithLifecycle(initialValue = "")
+    var selected by remember(languageTag) { mutableStateOf(languageTag) }
+
+    val scope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.title_settings)) })
+        },
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.pref_language),
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            LanguageOptionRow(
+                selected = selected == "",
+                label = stringResource(R.string.pref_language_system),
+                onClick = { selected = "" },
+            )
+            LanguageOptionRow(
+                selected = selected == "ja",
+                label = stringResource(R.string.pref_language_ja),
+                onClick = { selected = "ja" },
+            )
+            LanguageOptionRow(
+                selected = selected == "en",
+                label = stringResource(R.string.pref_language_en),
+                onClick = { selected = "en" },
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(
+                    onClick = onBack,
+                ) { Text(stringResource(R.string.action_close)) }
+
+                Button(
+                    onClick = {
+                        scope.launch {
+                            AppLocaleManager.setLanguage(ctx, selected)
+                            // ★ Added: 反映のため必要なら Activity 再生成
+                            activity?.recreate()
+                        }
+                    },
+                    enabled = selected != languageTag,
+                ) { Text(stringResource(R.string.action_apply)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LanguageOptionRow(
+    selected: Boolean,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -22,6 +22,7 @@
     <string name="cd_open_search">Search</string>
     <string name="cd_open_mindmap_dev">Mind Map(Prototype)</string>
     <string name="cd_clear_folder_filter">Remove folder filtering</string>
+    <string name="cd_open_settings">Settings</string>
 
     <!-- For reviewing the folder selection menu -->
     <string name="menu_unselected_none">Unselected</string>
@@ -55,5 +56,14 @@
     <string name="snack_deleted">Deleted</string>
     <string name="snack_child_added">Added child node</string>
     <string name="snack_undo">Undo</string>
+
+    <!-- Settings -->
+    <string name="title_settings">Settings</string>
+    <string name="pref_language">App language</string>
+    <string name="pref_language_system">Follow system</string>
+    <string name="pref_language_ja">Japanese</string>
+    <string name="pref_language_en">English</string>
+    <string name="action_apply">Apply</string>
+    <string name="action_close">Close</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="cd_open_search">検索</string> <!-- ★ keep -->
     <string name="cd_open_mindmap_dev">Mind Map（試験機能）</string> <!-- ★ keep -->
     <string name="cd_clear_folder_filter">フォルダ絞り込みを解除</string> <!-- ★ Added: BugsScreenのClearボタン用 -->
+    <string name="cd_open_settings">設定</string>
 
     <!-- 空状態（将来の置き換え用: 現状未使用なら保持だけ） -->
     <string name="empty_no_memo">メモがありません</string> <!-- ★ Added: EmptyMessage 文言 -->
@@ -53,6 +54,13 @@
     <string name="label_title">タイトル</string>
     <string name="label_content">内容</string>
 
-
+    <!-- ★ Added: 設定画面 -->
+    <string name="title_settings">設定</string>
+    <string name="pref_language">アプリの言語</string>
+    <string name="pref_language_system">端末の言語に合わせる</string>
+    <string name="pref_language_ja">日本語</string>
+    <string name="pref_language_en">English</string>
+    <string name="action_apply">適用</string>
+    <string name="action_close">閉じる</string>
 
 </resources>

--- a/app/src/main/res/xml/locale_config.xml
+++ b/app/src/main/res/xml/locale_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="ja" />
+    <locale android:name="en" />
+</locale-config>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,10 +9,11 @@ kotlin = "2.2.20"
 # compose-material-icons = "1.7.8"                     # （BOM配下のため不要）
 coreKtx = "1.17.0"
 datastore = "1.1.7"
-room = "2.8.1"               # KSP とは別（Room 本体のバージョン）
+room = "2.8.2"               # KSP とは別（Room 本体のバージョン）
 lifecycle = "2.9.4"
 activityCompose = "1.11.0"
-composeBom = "2025.09.01"
+composeBom = "2025.10.00"
+appcompat = "1.7.1"
 
 # テスト系
 junit = "4.13.2"
@@ -56,6 +57,9 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 
 # DataStore
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+
+# Appcompat
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 
 # テスト
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## 目的
アプリ内で言語切替（System/JA/EN）を即時反映 + lint-baseline の整理。

## 変更概要
- 設定画面を追加し、アプリ内で言語切替（System/JA/EN）を即時反映できるようにしました。
- 既存画面の文言を strings.xml に集約（BugsScreen / NoteEditor / MindMap の一部）。
- IME表示時の下部被りを回避（imePadding()）。
- lint-baseline を最新結果に合わせて整理。

# 変更点
## SettingsScreen.kt
- 言語選択（System / 日本語 / English）UIを追加。AppLocaleManager 経由で適用。必要に応じて Activity.recreate()。

## AppLocaleManager.kt
- DataStoreで言語タグを保持。languageTagFlow() を = 式で簡潔化（spotless適用）。

## ナビゲーション/導線
- BugsScreenのAppBarに「設定」アイコン（onOpenSettings）を追加（NavGraph側で配線）。

## 文言のリソース化
- BugsScreenのタイトル/EmptyMessage/各種CD（contentDescription）を strings.xml に移行。
- NoteEditorScreenのタイトル・ラベルを stringResource() に置換。
- MindMapScreenのSnackbar/ボタン文言は段階的にリソース化済み/必要分のみ対応
- 英語 values-en/strings.xml を追加・同期。

## UI/UX
- NoteEditorScreen に Modifier.imePadding() を付与（キーボード被り回避）。
- MindMapScreen にも同様に imePadding() を付与。

## Lint / Spotless
- spotless適用で AppLocaleManager.kt を関数式に統一。
- baselineから未再現の古い GradleDependency 系4件を削除。
- AndroidManifest.xml の冗長な android:label（Activity）を削除、未使用の tools 名前空間も整理。