### PR TITLE
UI/Nav: BottomNav表示ルールの明確化＋トップレベル遷移の単一スタック化

### DIFF
--- a/app/src/main/java/com/example/bugmemo/ui/AppScaffold.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/AppScaffold.kt
@@ -22,11 +22,17 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.bugmemo.ui.navigation.AppNavHost
 import com.example.bugmemo.ui.navigation.Routes
 import kotlinx.coroutines.flow.collectLatest
+
+// ★ Added: トップレベル遷移のために startDestination を取得する拡張を import(androidx.navigation.NavGraph.Companion.findStartDestination)
+// ★ Changed: 表示/非表示判定でも使うために hierarchy を活用(androidx.navigation.NavDestination.Companion.hierarchy)
 
 @Composable
 fun AppScaffold(
@@ -34,8 +40,10 @@ fun AppScaffold(
     vm: NotesViewModel,
 ) {
     val navController = rememberNavController()
+
+    // ★ Changed: currentRoute 文字列比較 → Destination + hierarchy 判定に切替
     val backStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = backStackEntry?.destination?.route
+    val currentDestination = backStackEntry?.destination
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -62,13 +70,12 @@ fun AppScaffold(
         }
     }
 
+    // ★ keep: BottomNav に載せるトップレベル3画面
     val navItems = listOf(
         NavItem("Bugs", Routes.BUGS) {
-            // ★ Fixed: カンマ後の余計なスペースを削除（1スペースに）
             Icon(Icons.AutoMirrored.Filled.List, contentDescription = "Bugs")
         },
         NavItem("Search", Routes.SEARCH) {
-            // ★ Fixed: 同上
             Icon(Icons.Filled.Search, contentDescription = "Search")
         },
         NavItem("Folders", Routes.FOLDERS) {
@@ -76,28 +83,41 @@ fun AppScaffold(
         },
     )
 
+    // ★ Added: BottomNav 表示対象のルート集合（Routes に同様の set があるならそれを参照してもOK）
+    val bottomBarRoutes = setOf(Routes.BUGS, Routes.SEARCH, Routes.FOLDERS)
+
+    // ★ Added: 現在の Destination が BottomNav 対象かどうかを階層で判定
+    val showBottomBar = shouldShowBottomBar(currentDestination, bottomBarRoutes)
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
-            NavigationBar {
-                navItems.forEach { item ->
-                    val selected = currentRoute == item.route
-                    NavigationBarItem(
-                        selected = selected,
-                        onClick = {
-                            if (!selected) {
+            // ★ Added: 表示/非表示をここで切り替え（EDITOR/SETTINGS/MINDMAP では非表示）
+            if (showBottomBar) {
+                NavigationBar {
+                    navItems.forEach { item ->
+                        // ★ Changed: 階層内に一致する route があるかで選択状態を判定（ネストに強い）
+                        val selected =
+                            currentDestination?.hierarchy?.any { it.route == item.route } == true
+                        NavigationBarItem(
+                            selected = selected,
+                            onClick = {
+                                // ★ Changed: トップレベル間は1スタック化し、状態保存/復元を有効化
                                 navController.navigate(item.route) {
+                                    // 二重積み上げ防止
                                     launchSingleTop = true
+                                    // 以前の状態（スクロール位置など）を復元
                                     restoreState = true
-                                    popUpTo(navController.graph.startDestinationId) {
+                                    // スタート先まで popUp して重複スタックを防ぐ
+                                    popUpTo(navController.graph.findStartDestination().id) {
                                         saveState = true
                                     }
                                 }
-                            }
-                        },
-                        icon = { item.icon() },
-                        label = { Text(item.label) },
-                    )
+                            },
+                            icon = { item.icon() },
+                            label = { Text(item.label) },
+                        )
+                    }
                 }
             }
         },
@@ -120,3 +140,14 @@ private data class NavItem(
     val route: String,
     val icon: @Composable () -> Unit,
 )
+
+// ★ Added: BottomNav 表示判定ヘルパー（階層を見て安全に判定）
+private fun shouldShowBottomBar(
+    destination: NavDestination?,
+    bottomBarRoutes: Set<String>,
+): Boolean {
+    // destination が null（初期描画中など）の時は表示しても OK にしておく（必要なら false にしても良い）
+    if (destination == null) return true
+    // ★ Added: 初期状態の見た目優先（任意で false に変更可）
+    return destination.hierarchy.any { it.route in bottomBarRoutes }
+}


### PR DESCRIPTION
### 目的
ナビゲーションの一貫性と戻りやすさを改善。

### 変更点
- BottomNav を BUGS/SEARCH/FOLDERS のみ表示、EDITOR/SETTINGS/MINDMAP では非表示に
- トップレベル遷移は launchSingleTop + restoreState + popUpTo(start) で単一スタック化
- BugsScreen の「検索」「フォルダ」（AppBar）も同ポリシーに統一
- 付随：IME被り回避（imePadding）維持／既存コードの軽微整理

### 動作確認
- [ ] BUGS ⇄ SEARCH ⇄ FOLDERS の往復で戻れなくならない
- [ ] EDITOR/SETTINGS/MINDMAP では BottomNav が出ない
- [ ] AppBar の「検索」「フォルダ」から遷移→戻るが直感どおり
- [ ] 回転・再生成でも異常なし

### 影響範囲・リスク
- Nav 挙動（戻る・履歴）のみ。データ処理には非影響。

### CI
- spotlessCheck / lint / test / assembleDebug ✅ 済