### PR TITLE
docs:Nav.kt の構造解説 & 設定（SettingsScreen + AppLocaleManager）の実装ノート

### DIFF
--- a/docs/architecture/app_scaffold.md
+++ b/docs/architecture/app_scaffold.md
@@ -1,0 +1,30 @@
+# AppScaffold アーキテクチャ概要
+
+本書は `AppScaffold.kt` の役割と実装方針を、面談やレビューで説明しやすい粒度で整理したものです。
+
+## 目的
+- アプリ全体の「足場」：`Scaffold`（BottomNav / Snackbar）＋ `NavHost`（画面遷移）＋ 共通 UI イベント購読。
+
+## 構成要素
+- **NavController**: `rememberNavController()` で生成。遷移/BackStackを管理。
+- **現在地の状態化**: `currentBackStackEntryAsState()` → UI と宛先の同期。
+- **Snackbar**: `SnackbarHostState` を共有し、ViewModel の UI イベントを表示。
+
+## UI イベント購読
+`NotesViewModel.UiEvent` を購読してスナックバー表示。
+- Message: `showSnackbar(message, withDismissAction=true)`
+- UndoDelete: “削除しました / 取り消す” を表示 → 押下時に `vm.undoDelete()`
+
+## BottomNav（選択判定と遷移ポリシー）
+- **選択状態**: `currentDestination?.hierarchy?.any { it.route == item.route } == true`
+  → ネストしたグラフでも正しく選択表示。
+- **遷移ポリシー**（重複スタックを作らない & 状態復元）:
+
+```kotlin
+navController.navigate(item.route) {
+    launchSingleTop = true         // 同一画面の二重積み上げを防止
+    restoreState = true            // タブ戻りでスクロール位置などを復元
+    popUpTo(navController.graph.findStartDestination().id) {
+        saveState = true           // 以前の状態を保存
+    }
+}

--- a/docs/architecture/nav.md
+++ b/docs/architecture/nav.md
@@ -1,0 +1,52 @@
+# Nav アーキテクチャ概要
+
+## 目的
+- 画面遷移を1か所に集約し、拡張（画面追加・遷移方針変更）を安全にする。
+- 画面内ショートカット（検索/フォルダなど）とボトムナビの遷移ポリシー統一。
+
+## 管理ファイル
+- app/src/main/java/com/example/bugmemo/ui/navigation/Nav.kt
+- object Routes … ルート定義（BUGS, SEARCH, FOLDERS, EDITOR, MINDMAP, SETTINGS）
+- @Composable fun AppNavHost(...) … NavHost + 各 composable 登録
+
+## グラフ構成（startDestination と各 Destination）
+- startDestination = Routes.BUGS
+- Routes.BUGS → BugsScreen
+- 引数なし。ハンドラで onOpenEditor などのラムダを受けて遷移。
+- Routes.SEARCH → SearchScreen
+- Routes.FOLDERS → FoldersScreen
+- Routes.EDITOR → NoteEditorScreen
+- Routes.MINDMAP → MindMapScreen（画面ローカルな MindMapViewModel = viewModel()）
+- Routes.SETTINGS → SettingsScreen（歯車アイコンから遷移）
+
+## 方針
+- VM の生成は上位（MainActivity / AppScaffold）で。
+- NotesViewModel は Bugs/Search/Folders/Editor で共有。MindMap は独立 VM。
+
+## 遷移ポリシー（重複スタックを作らない）
+## 画面内ショートカット
+- ボトムナビ共通で以下を徹底：
+- launchSingleTop = true（同一画面を二重に積まない）
+- restoreState = true（戻った時にスクロール等を復元）
+- popUpTo(findStartDestination().id) { saveState = true }（トップレベルは1スタック）
+- BugsScreen の AppBar の「検索」「フォルダ」など全てこのポリシーで navigate()。
+
+## 依存関係／import の注意
+- androidx.navigation.compose.NavHost, composable
+- findStartDestination(), hierarchy（選択状態の判定に使用）
+- VM は外から渡す（NotesViewModel）。MindMapViewModel のみ viewModel() でローカル生成。
+
+## 画面追加の手順（チェックリスト）
+- Routes に定数を追加（例：const val SETTINGS = "settings"）。
+- AppNavHost に composable(Routes.SETTINGS) { SettingsScreen(...) } を追加。
+- 呼び出し元（例：BugsScreen のアイコン）から遷移ラムダを配線。
+- トップレベル化するならBottomNav への追加＋選択状態の判定更新。
+- 文字列（CD 含む）を strings.xml に追加。
+
+## よくある落とし穴
+## 別画面から戻れない
+- ボトムナビ・ショートカット双方で前述の navigate オプション統一が必須。
+## VM が二重生成
+- viewModel() を画面内で呼ばず、MainActivity/AppScaffold から渡す（MindMap だけ例外）。
+## CD の付け忘れ
+- アイコン contentDescription は strings に集約。

--- a/docs/architecture/settingsscreen + appLocalemanager.md
+++ b/docs/architecture/settingsscreen + appLocalemanager.md
@@ -1,0 +1,67 @@
+# SettingsScreen + AppLocaleManager アーキテクチャ概要
+
+## 目的
+    - 設定画面からアプリ内で言語とエディタ文字サイズを切り替え、即時反映できるようにする。
+## 管理ファイル
+    - 画面：app/src/main/java/com/example/bugmemo/ui/screens/SettingsScreen.kt
+    - 永続化：app/src/main/java/com/example/bugmemo/core/AppLocaleManager.kt
+    - 文字列：app/src/main/res/values/strings.xml（ja / en あり）
+
+## データモデル（DataStore）
+    - PREFS_NAME = "app_settings"
+
+## キー
+    - language_tag: String（""=システム追従 / "ja" / "en"）
+    - editor_font_scale: Float（例：0.85f..1.40f の範囲）
+
+## API
+    - languageTagFlow(context): Flow<String>
+    - setLanguage(context, tag: String) → DataStore 保存＋AppCompatDelegate.setApplicationLocales(...)
+    - editorFontScaleFlow(context): Flow<Float>
+    - setEditorFontScale(context, scale: Float)
+
+## SettingsScreen 構成
+    - TopAppBar：title_settings
+## 言語
+    - 表示：pref_language タイトル＋ラジオ 3択
+    - 状態：languageTagFlow(ctx) を購読 → selected（remember(languageTag) 初期化）
+    - ボタン：
+        - action_close：戻る
+        - action_apply：setLanguage() → 必要なら activity?.recreate()（即時反映）
+
+## エディタ文字サイズ
+    - 表示：pref_editor_font_scale 見出し、pref_editor_font_scale_value（現在値）
+    - スライダ：0.85f..1.40f、steps = 0（連続）
+    - 状態：editorFontScaleFlow(ctx) を購読 → scaleUi（rememberSaveable で回転/再生成も保持可）
+    - 反映：onValueChangeFinished で setEditorFontScale(ctx, scaleUi) を保存即時プレビューをしたい場合は onValueChange で UI 側にも反映（NoteEditor でスケール適用済み）
+
+## NoteEditorScreen での適用（参照）
+    - タイトル・本文の Text / OutlinedTextField に fontSize = base * scale を適用済み。
+    - これにより Settings のスライダ変更が視認できる（保存後 or 即時）。
+
+## 依存関係
+    - androidx.appcompat:appcompat（AppCompatDelegate 用）
+    - DataStore: androidx.datastore:datastore-preferences
+    - Compose: Material3 / Runtime / Lifecycle（collectAsStateWithLifecycle）
+
+## i18n / strings（代表）
+    - title_settings, pref_language, pref_language_system, pref_language_ja, pref_language_en
+    - action_apply, action_close
+    - pref_editor_font_scale, pref_editor_font_scale_value（例："Editor text size: %.0f%%"）
+
+## 用語解説
+i18n = “internationalization（インターナショナリゼーション）
+    - ソフトウェアを 多言語・多地域で使えるように設計／実装すること。
+
+具体例（Android 文脈）：
+    - 文字列を strings.xml に集約し、values-ja/values-en などで翻訳を切り替え
+
+## UX メモ
+    - 言語適用は即時だが、Compose ツリー再生成のため activity?.recreate() を併用が無難。
+    - フォントスケールは即時プレビュー or 適用時反映の二段構え。現実装は「スライダ離したら保存」で十分に軽量。
+
+## よくある落とし穴
+    - “関数未使用” 警告：setEditorFontScale を呼ぶまで出る。Settings のスライダ保存で解消。
+    - 言語タグが空："" は「システム追従」。LocaleListCompat.getEmptyLocaleList() を適用。
+    - 範囲外のスケール：スライダ値は coerceIn(0.85f, 1.40f) でガード。
+    - CD/文言のハードコード：Settings のタイトルやボタン含め、strings に集約。


### PR DESCRIPTION
## 目的

プロジェクト理解を早めるため、ナビゲーション構成とローカライズ（言語切替）の要点をまとめたドキュメントを追加します。

- 実装（Nav.kt / SettingsScreen / AppLocaleManager）の設計意図・責務分離・使い方を1箇所で参照できるようにします。

## 変更内容

## Docs 追加

- docs/arch/nav.md … AppNavHost／Routes／遷移ポリシー（launchSingleTop/restoreState/popUpTo）の説明とサンプル

- docs/features/settings-language.md … SettingsScreen（UI）＋ AppLocaleManager（DataStore + AppCompatDelegate）の解説、保存キー、再現手順、注意点

## 注記: 本PRはドキュメントのみで、アプリの実行時挙動は変わりません。

## 背景

## 既に実装済み

    - Nav.kt でトップレベル画面（Bugs/Search/Folders/Settings）を集約。

    - SettingsScreen で言語切替（ja/en/システム追従）を提供。

    - AppLocaleManager が DataStore へ保存し、AppCompatDelegate.setApplicationLocales で即時反映。

## レビュー観点

    - ドキュメントの内容が 現行コード（Nav.kt / SettingsScreen.kt / AppLocaleManager.kt）と一致しているか

    - 遷移ポリシー（launchSingleTop / restoreState / popUpTo(startDestination){ saveState=true }）の説明が実装と矛盾ないか

    - 保存キー名・データ型（language_tag / editor_font_scale）の表記が正しいか

    - 参考リンク・注意点（Activity 再生成、strings.xml のキー一覧など）の不足がないか

## 動作確認

- アプリ起動 → Bugs 画面の AppBar 歯車から Settings へ遷移

- 言語を ja/en/システム で切替 → Apply → 画面文言が切替ること（Activity再生成）

- BottomNavigation：Bugs/Search/Folders を行き来しても スタックが重複しない（戻る挙動が直感的）こと

- チェックリスト / Checklist

    - ./gradlew spotlessApply spotlessCheck 済

    - ./gradlew :app:lint assembleDebug 通過

    - ドキュメント内のコードスニペットが実装と一致

    - strings.xml キー名の表記ゆれ無し