### PR TITLE
Nav:Nav配線の一貫化＆BottomNavの表示ルール整理（共通ヘルパ導入）

### DIFF
--- a/app/src/main/java/com/example/bugmemo/ui/AppScaffold.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/AppScaffold.kt
@@ -89,6 +89,22 @@ fun AppScaffold(
     // ★ Added: 現在の Destination が BottomNav 対象かどうかを階層で判定
     val showBottomBar = shouldShowBottomBar(currentDestination, bottomBarRoutes)
 
+    // ─────────────────────────────────────────────────────────────
+    // ★ Added: トップレベル画面間の“共通ナビゲーション”ヘルパ
+    //   - launchSingleTop: 二重積み上げ防止
+    //   - restoreState   : 以前の状態（スクロール等）復元
+    //   - popUpTo(start) : トップレベル間の重複スタック化を防止（saveState で戻れる）
+    fun navigateTopLevel(route: String) {
+        navController.navigate(route) {
+            launchSingleTop = true
+            restoreState = true
+            popUpTo(navController.graph.findStartDestination().id) {
+                saveState = true
+            }
+        }
+    }
+    // ─────────────────────────────────────────────────────────────
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
@@ -102,17 +118,8 @@ fun AppScaffold(
                         NavigationBarItem(
                             selected = selected,
                             onClick = {
-                                // ★ Changed: トップレベル間は1スタック化し、状態保存/復元を有効化
-                                navController.navigate(item.route) {
-                                    // 二重積み上げ防止
-                                    launchSingleTop = true
-                                    // 以前の状態（スクロール位置など）を復元
-                                    restoreState = true
-                                    // スタート先まで popUp して重複スタックを防ぐ
-                                    popUpTo(navController.graph.findStartDestination().id) {
-                                        saveState = true
-                                    }
-                                }
+                                // ★ Changed: 直接 navigate を書かず共通ヘルパを使用
+                                if (!selected) navigateTopLevel(item.route)
                             },
                             icon = { item.icon() },
                             label = { Text(item.label) },

--- a/app/src/main/java/com/example/bugmemo/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/SearchScreen.kt
@@ -39,9 +39,11 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.bugmemo.data.Note
 import com.example.bugmemo.ui.NotesViewModel
+
+// ★ Removed: 画面内での viewModel() 生成は廃止（親から渡されるため）
+// import androidx.lifecycle.viewmodel.compose.viewModel
 
 /**
  * 検索画面（Bugs のクエリと同じ状態を共有）
@@ -51,8 +53,9 @@ import com.example.bugmemo.ui.NotesViewModel
  */
 @Composable
 fun SearchScreen(
-    // ★ Added: Editor に遷移するコールバック（Nav から受け取る）
-    vm: NotesViewModel = viewModel(),
+    // ★ Changed: viewModel() のデフォルト生成をやめ、親（Nav）から渡す
+    vm: NotesViewModel, // ★ Changed
+    // ★ keep: Editor に遷移するラムダ（Nav から受け取る）
     onOpenEditor: () -> Unit = {},
 ) {
     val query by vm.query.collectAsStateWithLifecycle(initialValue = "")
@@ -62,6 +65,7 @@ fun SearchScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Search") },
+                // TODO: 必要なら strings.xml にリソース化可能
                 actions = {
                     // 検索フィールド（シンプル版）
                     OutlinedTextField(
@@ -69,6 +73,7 @@ fun SearchScreen(
                         onValueChange = { vm.setQuery(it) },
                         singleLine = true,
                         placeholder = { Text("キーワードを入力") },
+                        // TODO: リソース化可能
                         leadingIcon = { Icon(Icons.Filled.Search, contentDescription = "Search") },
                         trailingIcon = {
                             if (query.isNotEmpty()) {
@@ -77,10 +82,9 @@ fun SearchScreen(
                                 }
                             }
                         },
-                        // ★ Added
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                         keyboardActions = KeyboardActions(
-                            onSearch = { /* 特に何もしなくても Flow が反映 */ },
+                            onSearch = { /* Flow により自動反映 */ },
                         ),
                         modifier = Modifier
                             .padding(end = 8.dp)
@@ -98,12 +102,16 @@ fun SearchScreen(
             if (query.isBlank()) {
                 EmptyHint(
                     title = "検索ワードを入力してください",
+                    // TODO: リソース化可能
                     subtitle = "例: クラッシュ / Retrofit / Compose",
+                    // TODO: リソース化可能
                 )
             } else if (results.isEmpty()) {
                 EmptyHint(
                     title = "0件でした",
+                    // TODO: リソース化可能
                     subtitle = "キーワードを変えて試してみましょう",
+                    // TODO: リソース化可能
                 )
             } else {
                 LazyColumn(
@@ -117,7 +125,7 @@ fun SearchScreen(
                             onClick = {
                                 // 編集対象をロード
                                 vm.loadNote(note.id)
-                                // ★ Added: Editor へ遷移
+                                // ★ keep: 受け取ったラムダで Editor へ遷移（Nav へ依存しない）
                                 onOpenEditor()
                             },
                             onToggleStar = { vm.toggleStar(note.id, note.isStarred) },
@@ -149,6 +157,7 @@ private fun ResultRow(
             Column(Modifier.weight(1f)) {
                 Text(
                     text = note.title.ifBlank { "(無題)" },
+                    // TODO: リソース化可能（label_untitled 等）
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -164,8 +173,10 @@ private fun ResultRow(
             IconButton(onClick = onToggleStar) {
                 if (note.isStarred) {
                     Icon(Icons.Filled.Star, contentDescription = "Starred")
+                    // TODO: リソース化可能
                 } else {
                     Icon(Icons.Outlined.StarBorder, contentDescription = "Not starred")
+                    // TODO: リソース化可能
                 }
             }
         }


### PR DESCRIPTION
### 変更概要
## AppScaffold
- 共通遷移ヘルパ navigateTopLevel(route) 導入（launchSingleTop/restoreState/popUpTo(start)）

## BottomNav
- 表示/非表示を shouldShowBottomBar() で判定（BUGS/SEARCH/FOLDERS のみ表示）

## Nav.kt
- 各画面へ “遷移ラムダ” を配線（画面側で navController を使わない方針に統一）

## BugsScreen/SearchScreen/FoldersScreen
- AppBar のアイコン遷移を受け取ったラムダ経由に置換（重複スタック防止）

## 動作確認
- BottomNav から BUGS/SEARCH/FOLDERS 相互遷移 OK、スタック重複なし
- AppBar から SEARCH⇄FOLDERS→BUGS でも正しく BUGS に遷移
- Lint/spotless/test/assembleDebug すべて成功