### PR TITLE
feat(nav):ナビゲーション改善＋新画面追加

### DIFF
--- a/app/src/main/java/com/example/bugmemo/ui/screens/AllNotesScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/AllNotesScreen.kt
@@ -1,0 +1,166 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.example.bugmemo.ui.screens
+
+// ★ Added: 一覧専用の軽量画面（小PR向け）
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.bugmemo.data.Note
+import com.example.bugmemo.ui.NotesViewModel
+
+@Composable
+fun AllNotesScreen(
+    // ★ keep: Nav から渡す
+    onBack: () -> Unit = {},
+    onOpenEditor: () -> Unit = {},
+    vm: NotesViewModel = viewModel(),
+) {
+    val notes by vm.notes.collectAsStateWithLifecycle(initialValue = emptyList())
+    // ★ Added: “スターのみ”の簡易フィルタ（画面ローカル・低リスク）
+    var starredOnly by remember { mutableStateOf(false) }
+    val list = if (starredOnly) notes.filter { it.isStarred } else notes
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("All Notes") },
+                // ★ 小PRのため文字列は直書き（必要なら strings に昇格）
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    // ★ Added: スターのみ表示トグル（軽量な視認性改善）
+                    FilterChip(
+                        selected = starredOnly,
+                        onClick = { starredOnly = !starredOnly },
+                        label = { Text(if (starredOnly) "Starred only" else "All") },
+                    )
+                },
+            )
+        },
+    ) { inner ->
+        if (list.isEmpty()) {
+            EmptyAllNotesHint(Modifier.padding(inner))
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .padding(inner)
+                    .fillMaxSize(),
+                contentPadding = PaddingValues(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(list, key = { it.id }) { note ->
+                    AllNoteRow(
+                        note = note,
+                        onClick = {
+                            vm.loadNote(note.id)
+                            onOpenEditor()
+                        },
+                        onToggleStar = { vm.toggleStar(note.id, note.isStarred) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AllNoteRow(
+    note: Note,
+    onClick: () -> Unit,
+    onToggleStar: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 1.dp,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable(onClick = onClick)
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = note.title.ifBlank { "(無題)" },
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = note.content,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            IconButton(onClick = onToggleStar) {
+                if (note.isStarred) {
+                    Icon(Icons.Filled.Star, contentDescription = "Starred")
+                } else {
+                    Icon(Icons.Outlined.StarBorder, contentDescription = "Not starred")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyAllNotesHint(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 32.dp),
+        tonalElevation = 0.dp,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("メモがありません", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "作成したメモがここに一覧表示されます",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/bugmemo/ui/screens/BugsScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/BugsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Folder
@@ -62,13 +63,14 @@ import com.example.bugmemo.data.Folder
 import com.example.bugmemo.data.Note
 import com.example.bugmemo.ui.NotesViewModel
 
+// ★ Added: 一覧アイコンを追加(androidx.compose.material.icons.filled.ViewList)
 // ★ Added: 設定アイコン(androidx.compose.material.icons.filled.Settings)
 // ★ Added: 文字列リソース参照(androidx.compose.ui.res.stringResource)
 // ★ Added: R を参照(com.example.bugmemo.R)
 // ★ Added: スクロール用の状態を追加(androidx.compose.foundation.rememberScrollState)
 // ★ Added: 縦スクロール修飾子を追加(androidx.compose.foundation.verticalScroll)
 
-/* ★ Added: トップレベル遷移を“必ず”ラムダ経由で実行するための超小さな共通ヘルパ
+/* ★ keep: トップレベル遷移を“必ず”ラムダ経由で実行するための超小さな共通ヘルパ
    - 実際のスタック方針は呼び出し側（AppScaffold/Nav）で実装
    - ここでは必ず経由させることでポリシーを統一（将来の差し替えも一箇所） */
 private fun performTopLevelNav(navigate: () -> Unit) {
@@ -84,13 +86,14 @@ fun BugsScreen(
     onOpenFolders: () -> Unit = {},
     onOpenMindMap: () -> Unit = {},
     onOpenSettings: () -> Unit = {},
+    onOpenAllNotes: () -> Unit = {},
+    // ★ Added: “All Notes（一覧画面）” への遷移フックを追加
     // ★ keep: MindMap への導線（Nav から渡す）
 ) {
     val notes by vm.notes.collectAsStateWithLifecycle(initialValue = emptyList())
     val folders by vm.folders.collectAsStateWithLifecycle(initialValue = emptyList())
     val editing by vm.editing.collectAsStateWithLifecycle(initialValue = null)
     val filterFolderId by vm.filterFolderId.collectAsStateWithLifecycle(initialValue = null)
-
     var showFolderMenu by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -108,6 +111,15 @@ fun BugsScreen(
                     )
                 },
                 actions = {
+                    // ★ Added: “All Notes（一覧）” を開くアイコンを最初に追加
+                    IconButton(onClick = { performTopLevelNav(onOpenAllNotes) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ViewList,
+                            contentDescription = "Open all notes",
+                            // ★ Added: 小PRのため直書き
+                        )
+                    }
+
                     // ★ Changed: 画面内ショートカットも共通ヘルパを経由して呼ぶ（ナビ方針を統一）
                     IconButton(onClick = { performTopLevelNav(onOpenSettings) }) {
                         Icon(
@@ -182,12 +194,10 @@ fun BugsScreen(
                     }
                 }
             }
-
             VerticalDivider(
                 modifier = Modifier.fillMaxHeight(),
                 thickness = 1.dp,
             )
-
             // 右：エディタ
             EditorPane(
                 editing = editing,
@@ -274,7 +284,6 @@ private fun EditorPane(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text("編集", style = MaterialTheme.typography.titleLarge)
-
         OutlinedTextField(
             value = editing?.title.orEmpty(),
             onValueChange = onTitleChange,
@@ -282,7 +291,6 @@ private fun EditorPane(
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
         )
-
         OutlinedTextField(
             value = editing?.content.orEmpty(),
             onValueChange = onContentChange,
@@ -290,7 +298,6 @@ private fun EditorPane(
             minLines = 6,
             modifier = Modifier.fillMaxWidth(),
         )
-
         HorizontalDivider(thickness = 1.dp)
 
         // フォルダ選択

--- a/app/src/main/java/com/example/bugmemo/ui/screens/FoldersScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/FoldersScreen.kt
@@ -3,6 +3,7 @@
 
 package com.example.bugmemo.ui.screens
 
+// ★ Changed: import を整理（未使用除去・辞書順）
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
@@ -41,10 +43,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.bugmemo.data.Folder
 import com.example.bugmemo.ui.NotesViewModel
 import kotlinx.coroutines.launch
+
+// ★ Removed: 画面内での viewModel() 生成は廃止（親から渡すため）
+// import androidx.lifecycle.viewmodel.compose.viewModel
+// ★ Added: Bugs へ戻るショートカット(androidx.compose.material.icons.automirrored.filled.List)
 
 /**
  * フォルダ一覧画面（完成版）
@@ -54,13 +59,15 @@ import kotlinx.coroutines.launch
  */
 @Composable
 fun FoldersScreen(
+    // ★ Changed: viewModel() のデフォ生成をやめ、親（Nav）から渡す
+    vm: NotesViewModel, // ★ Changed
     // Nav から受け取るエディタ遷移のコールバック
-    vm: NotesViewModel = viewModel(),
     onOpenEditor: () -> Unit = {},
+    // ★ Added: Bugs（Notes）へトップレベル遷移するラムダ（Nav から受け取る）
+    onOpenNotes: () -> Unit = {}, // ★ Added
 ) {
     val folders by vm.folders.collectAsStateWithLifecycle(initialValue = emptyList())
     val currentFilter by vm.filterFolderId.collectAsStateWithLifecycle(initialValue = null)
-
     var newFolder by remember { mutableStateOf("") }
     val scope = rememberCoroutineScope()
 
@@ -68,10 +75,20 @@ fun FoldersScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Folders") },
+                // TODO: strings.xml へ移行可能
                 actions = {
+                    // ★ Added: Bugs へ戻るショートカット（Nav 側の共通ヘルパでトップレベル遷移）
+                    IconButton(onClick = onOpenNotes) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.List,
+                            contentDescription = "Bugs",
+                            // TODO: リソース化可能
+                        )
+                    }
                     if (currentFilter != null) {
                         IconButton(onClick = { vm.setFolderFilter(null) }) {
                             Icon(Icons.Filled.Clear, contentDescription = "Clear filter")
+                            // TODO: リソース化可能
                         }
                     }
                 },
@@ -91,6 +108,7 @@ fun FoldersScreen(
                     value = newFolder,
                     onValueChange = { newFolder = it },
                     label = { Text("新規フォルダ名") },
+                    // TODO: リソース化可能
                     singleLine = true,
                     modifier = Modifier.weight(1f),
                 )
@@ -107,6 +125,7 @@ fun FoldersScreen(
                     // ★ Added: 空文字のときは無効化して押せないようにする
                     enabled = newFolder.isNotBlank(),
                 ) { Text("追加") }
+                // TODO: リソース化可能
             }
 
             if (folders.isEmpty()) {
@@ -169,6 +188,7 @@ private fun FolderRow(
                 if (isActive) {
                     Text(
                         text = "（絞り込み中）",
+                        // TODO: リソース化可能
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.primary,
                     )
@@ -176,9 +196,11 @@ private fun FolderRow(
             }
             IconButton(onClick = { onCreateNoteHere(folder.id) }) {
                 Icon(Icons.Filled.Add, contentDescription = "Create note here")
+                // TODO: リソース化可能
             }
             IconButton(onClick = { onDelete(folder.id) }) {
                 Icon(Icons.Filled.Delete, contentDescription = "Delete folder")
+                // TODO: リソース化可能
             }
         }
     }
@@ -197,9 +219,11 @@ private fun EmptyFoldersMessage() {
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("フォルダがありません", style = MaterialTheme.typography.titleMedium)
+            // TODO: リソース化可能
             Spacer(Modifier.height(4.dp))
             Text(
                 "上の入力欄から追加できます",
+                // TODO: リソース化可能
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/example/bugmemo/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/example/bugmemo/ui/screens/SearchScreen.kt
@@ -3,6 +3,7 @@
 
 package com.example.bugmemo.ui.screens
 
+// ★ Changed: import は辞書順・未使用除去（ktlint/spotless を想定）
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -19,6 +20,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
@@ -44,6 +46,7 @@ import com.example.bugmemo.ui.NotesViewModel
 
 // ★ Removed: 画面内での viewModel() 生成は廃止（親から渡されるため）
 // import androidx.lifecycle.viewmodel.compose.viewModel
+// ★ Added: Bugs へ戻るショートカット(androidx.compose.material.icons.automirrored.filled.List)
 
 /**
  * 検索画面（Bugs のクエリと同じ状態を共有）
@@ -57,6 +60,8 @@ fun SearchScreen(
     vm: NotesViewModel, // ★ Changed
     // ★ keep: Editor に遷移するラムダ（Nav から受け取る）
     onOpenEditor: () -> Unit = {},
+    // ★ Added: Bugs（Notes）へトップレベル遷移するラムダ（Nav から受け取る）
+    onOpenNotes: () -> Unit = {}, // ★ Added
 ) {
     val query by vm.query.collectAsStateWithLifecycle(initialValue = "")
     val results by vm.notes.collectAsStateWithLifecycle(initialValue = emptyList())
@@ -67,6 +72,14 @@ fun SearchScreen(
                 title = { Text("Search") },
                 // TODO: 必要なら strings.xml にリソース化可能
                 actions = {
+                    // ★ Added: Bugs へ戻るショートカット（Nav 側の共通ヘルパでトップレベル遷移）
+                    IconButton(onClick = onOpenNotes) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.List,
+                            contentDescription = "Bugs",
+                            // TODO: リソース化可能
+                        )
+                    }
                     // 検索フィールド（シンプル版）
                     OutlinedTextField(
                         value = query,
@@ -74,11 +87,15 @@ fun SearchScreen(
                         singleLine = true,
                         placeholder = { Text("キーワードを入力") },
                         // TODO: リソース化可能
-                        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = "Search") },
+                        leadingIcon = {
+                            Icon(Icons.Filled.Search, contentDescription = "Search")
+                            // TODO: リソース化可能
+                        },
                         trailingIcon = {
                             if (query.isNotEmpty()) {
                                 IconButton(onClick = { vm.setQuery("") }) {
                                     Icon(Icons.Filled.Clear, contentDescription = "Clear")
+                                    // TODO: リソース化可能
                                 }
                             }
                         },
@@ -108,8 +125,7 @@ fun SearchScreen(
                 )
             } else if (results.isEmpty()) {
                 EmptyHint(
-                    title = "0件でした",
-                    // TODO: リソース化可能
+                    title = "0件でした", // TODO: リソース化可能
                     subtitle = "キーワードを変えて試してみましょう",
                     // TODO: リソース化可能
                 )


### PR DESCRIPTION
## 概要
- ALL_NOTES ルートを追加し、Search / Folders の AppBar ショートカットから AllNotesScreen へ遷移できるように配線。
- 重複スタックを回避し状態を復元するため、NavHostController.navigateTopLevel() を導入。
- 分かりやすさのため、コールバック名を onOpenNotes にリネーム（Search / Folders および Nav を更新）。